### PR TITLE
Decimal value support for 'so', 'eo', 'du', 'lso', 'leo', & 'ldu' in VideoAPI

### DIFF
--- a/features/video-transformation/overlay.md
+++ b/features/video-transformation/overlay.md
@@ -53,9 +53,9 @@ The position of subtitles cannot be controlled at this point.
 | lx          | `x` of the top-left corner in the base asset where layer's top-left corner would be placed.    |
 | ly          | `y` of the top-left corner in the base asset where layer's top-left corner would be placed.    |
 | lfo         | Position of layer in relative terms e.g. `center`, `top`, `left`, `bottom`, `right`, `top_left`, `top_right`, `bottom_left` and `bottom_right`. Default value is `center`.      |
-| lso         | Start time of the base video in seconds when the layer should appear. Positive numbers up to 2 decimal places |
-| ldu         | Duration in seconds during which layer should appear on the base video. Positive numbers up to 2 decimal places |
-| leo         | End time of the base video when this layer should disappear. In case both `leo` and `ldu` are present, `ldu` is ignored. Positive numbers up to 2 decimal places |
+| lso         | Start time of the base video in seconds when the layer should appear. It accepts a positive number upto two decimal e.g. 20 or 20.50 |
+| ldu         | Duration in seconds during which layer should appear on the base video. It accepts a positive number upto two decimal e.g. 20 or 20.50 |
+| leo         | End time of the base video when this layer should disappear. In case both `leo` and `ldu` are present, `ldu` is ignored. It accepts a positive number upto two decimal e.g. 20 or 20.50 |
 
 ## Transformation of layer
 

--- a/features/video-transformation/overlay.md
+++ b/features/video-transformation/overlay.md
@@ -53,10 +53,9 @@ The position of subtitles cannot be controlled at this point.
 | lx          | `x` of the top-left corner in the base asset where layer's top-left corner would be placed.    |
 | ly          | `y` of the top-left corner in the base asset where layer's top-left corner would be placed.    |
 | lfo         | Position of layer in relative terms e.g. `center`, `top`, `left`, `bottom`, `right`, `top_left`, `top_right`, `bottom_left` and `bottom_right`. Default value is `center`.      |
-| lso         | Start time of the base video in seconds when the layer should appear. |
-| ldu         | Duration in seconds during which layer should appear on the base video. |
-| leo         | End time of the base video when this layer should disappear. In case both `leo` and `ldu` are present, `ldu` is ignored.  |
-
+| lso         | Start time of the base video in seconds when the layer should appear. Positive numbers up to 2 decimal places |
+| ldu         | Duration in seconds during which layer should appear on the base video. Positive numbers up to 2 decimal places |
+| leo         | End time of the base video when this layer should disappear. In case both `leo` and `ldu` are present, `ldu` is ignored. Positive numbers up to 2 decimal places |
 
 ## Transformation of layer
 

--- a/features/video-transformation/resize-crop-and-other-common-video-transformations.md
+++ b/features/video-transformation/resize-crop-and-other-common-video-transformations.md
@@ -376,7 +376,7 @@ Specify start offset in seconds. The video before the start offset is removed fr
 
 Usage - `so-<value>`
 
-**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. `10.55`. It must be less than the duration of the input video.
+**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. 20 or 10.55. It must be less than the duration of the input video.
 
 ### End offset - (eo)
 
@@ -384,7 +384,7 @@ Specify end offset in seconds. The video after end offset is removed from the ou
 
 Usage - `eo-<value>`
 
-**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. `50.77`. It must be less than the duration of the input video.
+**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. 20 or 10.55. It must be less than the duration of the input video.
 
 ### Duration - (du)
 
@@ -392,7 +392,7 @@ Specify duration in seconds. It is often used with `so` to control duration of t
 
 Usage - `du-<value>`
 
-**Possible Values** - Specify the duration in seconds as a positive number up to 2 decimal places e.g. `50.77`. It must be less than or equal to the duration of the input video.
+**Possible Values** - Specify the duration in seconds as a positive number up to 2 decimal places e.g. 20 or 10.55. It must be less than or equal to the duration of the input video.
 
 ## Get thumbnail from a video
 

--- a/features/video-transformation/resize-crop-and-other-common-video-transformations.md
+++ b/features/video-transformation/resize-crop-and-other-common-video-transformations.md
@@ -376,7 +376,7 @@ Specify start offset in seconds. The video before the start offset is removed fr
 
 Usage - `so-<value>`
 
-**Possible Values** - Positive integer to specify the time in seconds e.g. `10`. It must be less than the duration of the input video.
+**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. `10.55`. It must be less than the duration of the input video.
 
 ### End offset - (eo)
 
@@ -384,7 +384,7 @@ Specify end offset in seconds. The video after end offset is removed from the ou
 
 Usage - `eo-<value>`
 
-**Possible Values** - Positive integer to specify the time in seconds e.g. `10`. It must be less than the duration of the input video.
+**Possible Values** - Specify the time in seconds as a positive number up to 2 decimal places e.g. `50.77`. It must be less than the duration of the input video.
 
 ### Duration - (du)
 
@@ -392,7 +392,7 @@ Specify duration in seconds. It is often used with `so` to control duration of t
 
 Usage - `du-<value>`
 
-**Possible Values** - Positive integer to specify the duration time in seconds e.g. `10`. It must be less than or equal to the duration of the input video.
+**Possible Values** - Specify the duration in seconds as a positive number up to 2 decimal places e.g. `50.77`. It must be less than or equal to the duration of the input video.
 
 ## Get thumbnail from a video
 


### PR DESCRIPTION
Video API now accepts the time/duration in seconds as a positive number up to 2 decimal places for following parameters:

- `so` - StartOffset to trim video or gif
- `eo` - EndOffset to trim video or gif
- `du` - Duration from startOffset to trim video or gif
- `lso` - LayerStartOffset for overlay layer
- `leo` - LayerEndOffset for overlay layer
- `ldu` - LayerDuration from LayerStartOffset for overlay layer

Examples: `12`, `12.00`, `12.55`, `12.5`
