### PR TITLE
correction: Default bg color for broder radius in video is black

### DIFF
--- a/features/video-transformation/resize-crop-and-other-common-video-transformations.md
+++ b/features/video-transformation/resize-crop-and-other-common-video-transformations.md
@@ -331,7 +331,7 @@ Usage - `r-<value>`
 **Possible Values** - Any positive integer or `max`.
 
 {% hint style="info" %}
-You can also change the background color of the video from the default white color using the [background parameter](resize-crop-and-other-common-video-transformations.md#background-color-bg).
+You can also change the background color of the video from the default black color using the [background parameter](resize-crop-and-other-common-video-transformations.md#background-color-bg).
 {% endhint %}
 
 {% tabs %}


### PR DESCRIPTION
The default background color for border radius is 'black'.

Example: https://ik.imagekit.io/ikmedia/sample-video.mp4?tr=r-50