### PR TITLE
fix: f-orig, vc-orig & ac-orig is not supported in VideoAPI

### DIFF
--- a/features/video-optimization/automatic-video-format-conversion.md
+++ b/features/video-optimization/automatic-video-format-conversion.md
@@ -30,10 +30,6 @@ Select settings from the left main menu. Inside Videos, under optimization, togg
 
 If you disabled automatic format conversion in the global settings, you can still choose to use this feature for a particular request using `f-auto` parameter.
 
-### How to deliver video in the original format?
-
-Use `f-orig` parameter to deliver video in the original input format.
-
 ### How to override the format?
 
 You can use the `f` parameter to override the format for a particular video request. The format that you specify in the `f` parameter will take precedence over any global settings.

--- a/features/video-transformation/resize-crop-and-other-common-video-transformations.md
+++ b/features/video-transformation/resize-crop-and-other-common-video-transformations.md
@@ -245,7 +245,7 @@ Video size is 406KB which is less than half of the original 1.1MB video. File si
 
 Used to specify the format of the output video. If no output format is specified then based on your settings in the dashboard, ImageKit.io automatically picks the best format for that video request.
 
-Possible values include `auto` ,`mp4` , `webm` , `orig`.
+Possible values include `auto` ,`mp4` , `webm`.
 
 **Default Value** - `auto`. You can disable [automatic video format conversion](../video-optimization/automatic-video-format-conversion.md) from the dashboard settings.&#x20;
 
@@ -253,7 +253,7 @@ Possible values include `auto` ,`mp4` , `webm` , `orig`.
 
 Used to specify the audio codec for encoding the output.
 
-Possible values include `aac`, `opus`, `orig`, and `none`.
+Possible values include `aac`, `opus`, and `none`.
 
 Use `none` for removing audio from the source video. So the output will have no audio.
 
@@ -261,11 +261,11 @@ Use `none` for removing audio from the source video. So the output will have no 
 
 Used to specify the video codec for encoding the output.
 
-Possible values include `h264`, `vp9`, `orig`, and `none`
+Possible values include `h264`, `vp9`, and `none`
 
 Use `none` for extracting audio from the source video. So the output will be an audio file.
 
-#### Valid combinations for format (f), audio codec (ac) & video codec
+#### Valid combinations for format (f), audio codec (ac) & video codec (vc)
 
 | f    | ac   | vc   |
 | ---- | ---- | ---- |


### PR DESCRIPTION
f-orig, vc-orig & ac-orig is not supported for video transformation, video-thumbnail and gif-to-video

#### Valid combinations for format (f), audio codec (ac) & video codec (vc)

| f    | ac   | vc   |
| ---- | ---- | ---- |
| mp4  | aac  | h264 |
| mp4  | aac  | none |
| mp4  | none | h264 |
| webm | opus | vp9  |
| webm | opus | none |
| webm | none | vp9  |