### PR TITLE
Correction in bg-blurred examples for image-transformations

### DIFF
--- a/features/image-transformations/resize-crop-and-other-transformations.md
+++ b/features/image-transformations/resize-crop-and-other-transformations.md
@@ -786,7 +786,7 @@ Limitation: Blurred background can only be used with `cm-pad_resize`
 Blur intensity `auto`: The intensity of blur is automatically adjusted based on the provided height (h) & width (w) in the transformation.
 
 {% tabs %}
-{% tab title="bg=blurred_12_N25" %}
+{% tab title="bg=blurred" %}
 URL - [https://ik.imagekit.io/demo/tr:h-600,w-800,cm-pad\_resize,bg-blurred/medium\_cafe\_B1iTdD0C.jpg](https://ik.imagekit.io/demo/tr:h-600,w-800,cm-pad\_resize,bg-blurred/medium\_cafe\_B1iTdD0C.jpg)
 
 ![cm-pad\_resize,bg-blurred](../../.gitbook/assets/medium_cafe-cm-pad\_resize,bg-blurred.png)


### PR DESCRIPTION
<img width="611" alt="Screenshot 2023-10-01 at 10 32 35 PM" src="https://github.com/imagekitio/docs-keep-a-changelog/assets/80034794/1d78044b-ff91-4c0b-9576-ca2feb735038">

<p style="text-align: center;">&#8595;</p>


<img width="608" alt="Screenshot 2023-10-01 at 10 34 57 PM" src="https://github.com/imagekitio/docs-keep-a-changelog/assets/80034794/85ac5faa-7ba0-4550-9ee3-e241024a22f5">


